### PR TITLE
adicionando endpoint identify_user_get

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ To run the server on a Docker container, please execute the following from the r
 docker build -t swagger_server .
 
 # starting up a container
-docker run --name swagger_server_cont -p 8080:8080 swagger_server
+docker run --rm --name swagger_server_cont -p 8080:8080 swagger_server
 ```

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ To run the server on a Docker container, please execute the following from the r
 docker build -t swagger_server .
 
 # starting up a container
-docker run -p 8080:8080 swagger_server
+docker run --name swagger_server_cont -p 8080:8080 swagger_server
 ```

--- a/swagger_server/controllers/default_controller.py
+++ b/swagger_server/controllers/default_controller.py
@@ -62,3 +62,14 @@ def verify_token_get():  # noqa: E501
     :rtype: None
     """
     return 'do some magic!'
+
+def identify_token_get():  # noqa: E501
+    """Retorna o id associado ao token de acesso
+
+     # noqa: E501
+
+
+    :rtype: int64
+    """
+    user=User()
+    return user.id()

--- a/swagger_server/controllers/default_controller.py
+++ b/swagger_server/controllers/default_controller.py
@@ -71,5 +71,4 @@ def identify_token_get():  # noqa: E501
 
     :rtype: int64
     """
-    user=User()
-    return user.id()
+    return 'do some magic!'

--- a/swagger_server/swagger/swagger.yaml
+++ b/swagger_server/swagger/swagger.yaml
@@ -40,6 +40,18 @@ paths:
       security:
       - basicAuth: []
       x-openapi-router-controller: swagger_server.controllers.default_controller
+  /identify_token:
+    get:
+      summary: Retorna o id associado ao token de acesso recebido
+      operationId: identify_token_get
+      responses:
+        "200":
+          description: ID do user
+        "401":
+          description: Token inválido
+      security:
+      - basicAuth: []
+      x-openapi-router-controller: swagger_server.controllers.default_controller
   /register:
     post:
       summary: Registra novo usuário

--- a/swagger_server/test/test_default_controller.py
+++ b/swagger_server/test/test_default_controller.py
@@ -68,6 +68,16 @@ class TestDefaultController(BaseTestCase):
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 
+    def test_identify_token_get(self):
+        """Test case for identify_token_get
+
+        Retorna o id associado ao token de acesso
+        """
+        response = self.client.open(
+            '/api/v1/identify_token',
+            method='GET')
+        self.assert200(response,
+                       'Response body is : ' + response.data.decode('utf-8'))
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
frontend não exibe nova endpoint, que foi inserida em controler/default_controller.py e swagger/swagger.yaml para retornar um id de user. Nota: um User genérico foi usado para ilustrar o id() no retorno, pois não soube como saber o token recebido e nem como obter um User a partir dele.